### PR TITLE
Allow region to be forced in query parameter

### DIFF
--- a/cmd/redirectserver/app/handlers.go
+++ b/cmd/redirectserver/app/handlers.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/registry.k8s.io/pkg/net/cidrs/aws"
 
 	"sigs.k8s.io/porche/cmd/redirectserver/pkg/blobcache"
+	"sigs.k8s.io/porche/cmd/redirectserver/pkg/features"
 )
 
 type MirrorConfig struct {
@@ -96,10 +97,12 @@ func (s *Server) serveBinaries(w http.ResponseWriter, r *http.Request) {
 
 	awsRegion := ""
 
-	// Allow region to be specified in a parameter, primarily for testing,
-	// but this might also be useful for clients that want to "guide" the mirror.
-	if s := r.URL.Query().Get("region"); strings.HasPrefix(s, "aws-") {
-		awsRegion = strings.TrimPrefix(s, "aws-")
+	if features.AllowRegionToBeSpecified.IsEnabled() {
+		// Allow region to be specified in a parameter, primarily for testing,
+		// but this might also be useful for clients that want to "guide" the mirror.
+		if s := r.URL.Query().Get("region"); strings.HasPrefix(s, "aws-") {
+			awsRegion = strings.TrimPrefix(s, "aws-")
+		}
 	}
 
 	if awsRegion == "" {

--- a/cmd/redirectserver/app/handlers.go
+++ b/cmd/redirectserver/app/handlers.go
@@ -94,34 +94,44 @@ func (s *Server) serveBinaries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// check if client is known to be coming from an AWS region
-	awsRegion, ipIsKnown := s.regionMapper.GetIP(clientIP)
-	if !ipIsKnown {
-		// no region match, redirect to fallback location
-		klog.V(2).InfoS("region not known; redirecting request to fallback location", "path", rPath)
-		s.redirectToCanonical(w, r)
-		return
+	awsRegion := ""
+
+	// Allow region to be specified in a parameter, primarily for testing,
+	// but this might also be useful for clients that want to "guide" the mirror.
+	if s := r.URL.Query().Get("region"); strings.HasPrefix(s, "aws-") {
+		awsRegion = strings.TrimPrefix(s, "aws-")
 	}
 
-	// check if blob is available in our S3 bucket for the region
-	mirrorBase, found := awsRegionToS3URL(awsRegion)
-	if !found {
-		// fall back to redirect to upstream
-		klog.InfoS("mirror not found for region; redirecting request to fallback location", "region", awsRegion)
-		s.redirectToCanonical(w, r)
-		return
+	if awsRegion == "" {
+		// check if client is known to be coming from an AWS region
+		region, ipIsKnown := s.regionMapper.GetIP(clientIP)
+		if !ipIsKnown {
+			// no region match, redirect to fallback location
+			klog.V(2).InfoS("region cannot be determined from IP; redirecting request to fallback location", "path", rPath)
+		} else {
+			awsRegion = region
+		}
 	}
 
-	mirrorURL := urlJoin(mirrorBase, rPath)
-	if s.mirrorCache.BlobExists(mirrorURL, mirrorBase, rPath) {
-		// blob known to be available in S3, redirect client there
-		klog.V(2).InfoS("redirecting request to mirror", "path", rPath, "mirror", mirrorBase)
-		http.Redirect(w, r, mirrorURL, http.StatusTemporaryRedirect)
-		return
+	if awsRegion != "" {
+		// check if we have a mirror in the region
+		mirrorBase, found := awsRegionToS3URL(awsRegion)
+		if !found {
+			klog.InfoS("mirror not found for region; redirecting request to fallback location", "region", awsRegion)
+		} else {
+			// check if blob is available in our S3 bucket for the region
+			mirrorURL := urlJoin(mirrorBase, rPath)
+			if s.mirrorCache.BlobExists(mirrorURL, mirrorBase, rPath) {
+				// blob known to be available in S3, redirect client there
+				klog.V(2).InfoS("redirecting request to mirror", "path", rPath, "mirror", mirrorBase)
+				http.Redirect(w, r, mirrorURL, http.StatusTemporaryRedirect)
+				return
+			}
+			// fall back to redirect to upstream
+			klog.V(2).InfoS("file not found in mirror; redirecting request to fallback location", "path", rPath, "mirror", mirrorBase)
+		}
 	}
 
-	// fall back to redirect to upstream
-	klog.V(2).InfoS("blob not found; redirecting request to fallback location", "path", rPath)
 	s.redirectToCanonical(w, r)
 }
 

--- a/cmd/redirectserver/pkg/features/flags.go
+++ b/cmd/redirectserver/pkg/features/flags.go
@@ -1,0 +1,51 @@
+// Copyright 2023 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// AllowRegionToBeSpecified controls whether users can force a region with the `region` query-parameter.
+var AllowRegionToBeSpecified = Feature{Key: "AllowRegionToBeSpecified"}
+
+// Feature is the type for a feature, that can be activated via the FEATURE_FLAGS env var.
+type Feature struct {
+	Key string
+
+	initOnce sync.Once
+	enabled  bool
+}
+
+// IsEnabled returns true if the feature is enabled.
+func (f *Feature) IsEnabled() bool {
+	f.initOnce.Do(f.init)
+	return f.enabled
+}
+
+// init populates the enabled value for the feature-flag, parsing the FEATURE_FLAGS env var
+func (f *Feature) init() {
+	featureFlags := os.Getenv("FEATURE_FLAGS")
+	fields := strings.FieldsFunc(featureFlags, func(r rune) bool {
+		return r == ','
+	})
+	for _, field := range fields {
+		if strings.EqualFold(field, f.Key) {
+			f.enabled = true
+		}
+	}
+}

--- a/cmd/redirectserver/pkg/features/flags_test.go
+++ b/cmd/redirectserver/pkg/features/flags_test.go
@@ -1,0 +1,55 @@
+// Copyright 2023 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestFeatureFlags(t *testing.T) {
+	grid := []struct {
+		Key         string
+		EnvVar      string
+		WantEnabled bool
+	}{
+		{Key: "Foo", EnvVar: "", WantEnabled: false},
+		{Key: "Foo", EnvVar: ",", WantEnabled: false},
+		{Key: "Foo", EnvVar: "Foo", WantEnabled: true},
+		{Key: "Bar", EnvVar: "Foo", WantEnabled: false},
+		{Key: "Bar", EnvVar: "Bar,Foo", WantEnabled: true},
+		{Key: "Foo", EnvVar: ",Bar,,Foo,,,", WantEnabled: true},
+		{Key: "Bar", EnvVar: "bar", WantEnabled: true},
+		{Key: "Bar", EnvVar: "bart", WantEnabled: false},
+		{Key: "Bar", EnvVar: "rebar", WantEnabled: false},
+	}
+
+	for _, g := range grid {
+		g := g
+		name := fmt.Sprintf("Key=%s,EnvVar=%s", g.Key, g.EnvVar)
+		t.Run(name, func(t *testing.T) {
+			oldEnvVar := os.Getenv("FEATURE_FLAGS")
+			defer func() { os.Setenv("FEATURE_FLAGS", oldEnvVar) }()
+			os.Setenv("FEATURE_FLAGS", g.EnvVar)
+
+			ff := Feature{Key: g.Key}
+			got := ff.IsEnabled()
+			if got != g.WantEnabled {
+				t.Errorf("IsEnabled did not give expected value; got=%v, want=%v", got, g.WantEnabled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This isn't a security issue, because we rely on a client-side redirect
anyway, and this is convenient for testing and maybe for clients that
want to identify as being close to a particular region.
