### PR TITLE
Mark test helper methods with t.Helper

### DIFF
--- a/cmd/redirectserver/main_test.go
+++ b/cmd/redirectserver/main_test.go
@@ -79,6 +79,7 @@ func TestIntegrationMain(t *testing.T) {
 
 	// TODO: fake being on AWS
 	testGet := func(ctx context.Context, relativePath string, wantStatusCode int, wantContent string) {
+		t.Helper()
 		url := "http://" + testAddr + "/" + relativePath
 		// Do not follow redirects
 		httpClient := &http.Client{


### PR DESCRIPTION
This helps with printing the right line numbers on test failures.
Looks like we only have one test helper method though!
