### PR TITLE
Update default fallback location

### DIFF
--- a/cmd/redirectserver/main.go
+++ b/cmd/redirectserver/main.go
@@ -42,7 +42,7 @@ func main() {
 	port := getEnv("PORT", "8080")
 
 	cfg := app.MirrorConfig{
-		CanonicalFallback: getEnv("FALLBACK_LOCATION", "https://artifacts.k8s.io/"),
+		CanonicalFallback: getEnv("FALLBACK_LOCATION", "https://storage.googleapis.com/k8s-artifacts-prod/"),
 		InfoURL:           "https://github.com/kubernetes-sigs/porche",
 		PrivacyURL:        "https://www.linuxfoundation.org/privacy-policy/",
 	}

--- a/cmd/redirectserver/main_test.go
+++ b/cmd/redirectserver/main_test.go
@@ -115,10 +115,10 @@ func TestIntegrationMain(t *testing.T) {
 	}
 
 	// test fetching non-hash, should be served via redirect
-	testGet(ctx, "binaries/kops/1.24.3/darwin/arm64/kops", http.StatusTemporaryRedirect, "<a href=\"https://artifacts.k8s.io/binaries/kops/1.24.3/darwin/arm64/kops\">Temporary Redirect</a>.\n\n")
+	testGet(ctx, "binaries/kops/1.24.3/darwin/arm64/kops", http.StatusTemporaryRedirect, "<a href=\"https://storage.googleapis.com/k8s-artifacts-prod/binaries/kops/1.24.3/darwin/arm64/kops\">Temporary Redirect</a>.\n\n")
 
 	// test fetching non-existent, should be served via redirect
-	testGet(ctx, "binaries/not-a-file", http.StatusTemporaryRedirect, "<a href=\"https://artifacts.k8s.io/binaries/not-a-file\">Temporary Redirect</a>.\n\n")
+	testGet(ctx, "binaries/not-a-file", http.StatusTemporaryRedirect, "<a href=\"https://storage.googleapis.com/k8s-artifacts-prod/binaries/not-a-file\">Temporary Redirect</a>.\n\n")
 
 	// test fetching privacy, should be served via redirect
 	testGet(ctx, "privacy", http.StatusTemporaryRedirect, "<a href=\"https://www.linuxfoundation.org/privacy-policy/\">Temporary Redirect</a>.\n\n")


### PR DESCRIPTION
We want a value that won't self-redirect.  This shouldn't be hit anyway, because we should be overriding it.

Note that we'll likely set a different value in deployments (per environment), this is just a much safer default that won't cause an infinite redirect loop if we forget to do that!