### PR TITLE
Run with specific version of go

### DIFF
--- a/dev/ci/presubmit-build
+++ b/dev/ci/presubmit-build
@@ -10,4 +10,7 @@ set -o pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
+# Install preferred golang version into PATH
+. dev/helpers/ci-install-golang.sh
+
 dev/build

--- a/dev/ci/presubmit-lint
+++ b/dev/ci/presubmit-lint
@@ -15,4 +15,7 @@ mkdir -p "${REPO_ROOT}/bin"
 dev/helpers/ci-install-shellcheck.sh
 export PATH="${REPO_ROOT}/bin:${PATH}"
 
+# Install preferred golang version into PATH
+. dev/helpers/ci-install-golang.sh
+
 dev/lint

--- a/dev/ci/presubmit-test
+++ b/dev/ci/presubmit-test
@@ -10,4 +10,7 @@ set -o pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
+# Install preferred golang version into PATH
+. dev/helpers/ci-install-golang.sh
+
 dev/test

--- a/dev/ci/presubmit-verify
+++ b/dev/ci/presubmit-verify
@@ -10,6 +10,9 @@ set -o pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
+# Install preferred golang version into PATH
+. dev/helpers/ci-install-golang.sh
+
 dev/format
 
 dev/helpers/error-if-changes.sh

--- a/dev/helpers/ci-install-golang.sh
+++ b/dev/helpers/ci-install-golang.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# script to install go in CI
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VERSION="1.19.5"
+HASH="36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+cd /tmp/
+echo "Installing go ${VERSION} from upstream to ensure CI version ..."
+curl -L https://go.dev/dl/go${VERSION}.linux-amd64.tar.gz -o go.tar.gz
+
+sha256sum --check - <<EOF
+${HASH}  go.tar.gz
+EOF
+
+tar zxf go.tar.gz
+
+export PATH="/tmp/go/bin:${PATH}"
+cd "${REPO_ROOT}"
+go version


### PR DESCRIPTION
This ensures a more reproducible build.
